### PR TITLE
Use regular cargo cache for coverage

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -33,6 +33,7 @@ matrix:
     - name: coverage
       rust: nightly-2019-05-20
       sudo: required
+      cache: cargo
       env: RUSTFLAGS="--cfg procmacro2_semver_exempt"
       addons:
         apt:


### PR DESCRIPTION
We _really_ want to cache cargo-update and cargo-tarpaulin

bors: r+