### PR TITLE
Enable `UnwindSafe` for `Id` and update tests and docs

### DIFF
--- a/tests/ui/crossed_streams.stderr
+++ b/tests/ui/crossed_streams.stderr
@@ -2,7 +2,7 @@ error[E0597]: `tag` does not live long enough
  --> $DIR/crossed_streams.rs:5:5
   |
 5 |     make_guard!(b);
-  |     ^^^^^^^^^^^^^^^ borrowed value does not live long enough
+  |     ^^^^^^^^^^^^^^ borrowed value does not live long enough
 6 |     dbg!(a == b); // ERROR (here == is a static check)
 7 | }
   | -
@@ -11,6 +11,4 @@ error[E0597]: `tag` does not live long enough
   | borrow might be used here, when `_guard` is dropped and runs the `Drop` code for type `main::make_guard`
   |
   = note: values in a scope are dropped in the opposite order they are defined
-  = note: this error originates in a macro outside of the current crate (in Nightly builds, run with -Z external-macro-backtrace for more info)
-
-For more information about this error, try `rustc --explain E0597`.
+  = note: this error originates in the macro `make_guard` (in Nightly builds, run with -Z macro-backtrace for more info)


### PR DESCRIPTION
[UnwindSafe](https://doc.rust-lang.org/core/panic/trait.UnwindSafe.html) is a Rust auto-trait to define types that are panic safe. `&mut T` is not `UnwindSafe`, so including it in the definition of `Id` makes any struct using it not `UnwindSafe` either.

- Changed the `Id` lifetime to a definition that is still invariant but `UnwindSafe`. Added a new test to ensure this property holds in the future.
- Fixed the `trybuild` tests with the output of Rust 1.60.0
- Updated the docstring to better explain the uses of the different types.
- Hid the docstring of items that should not be part of the public interface.

See uazu/qcell#31