### PR TITLE
more specific compiler errors, more general make_guard!

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,4 +11,4 @@ categories = ["no-std", "rust-patterns"]
 license = "MIT OR Apache-2.0"
 
 [dev-dependencies]
-trybuild = "1.0.85"
+trybuild = "=1.0.85"

--- a/tests/ui/crossed_streams.stderr
+++ b/tests/ui/crossed_streams.stderr
@@ -1,16 +1,16 @@
-error[E0597]: `branded_place` does not live long enough
+error[E0597]: `b` does not live long enough
  --> tests/ui/crossed_streams.rs:5:5
   |
 5 |     make_guard!(b);
   |     ^^^^^^^^^^^^^^
   |     |
   |     borrowed value does not live long enough
-  |     binding `branded_place` declared here
+  |     binding `b` declared here
 6 |     dbg!(a == b); // ERROR (here == is a static check)
 7 | }
   | -
   | |
-  | `branded_place` dropped here while still borrowed
+  | `b` dropped here while still borrowed
   | borrow might be used here, when `lifetime_brand` is dropped and runs the `Drop` code for type `LifetimeBrand`
   |
   = note: values in a scope are dropped in the opposite order they are defined


### PR DESCRIPTION
amazing crate! hope it's fine for me to suggest a few improvements

this pr makes the constructors of `Id` and `Guard` const, allows multiple identifiers in `make_guard!`, and makes the compiler error for mismatching lifetimes point to the relevant guards instead of the compiler always complaining about `branded_place`, which should be an implementation detail