### PR TITLE
Fix `make_guard!()` unsoundness in the presence of diverging code afterwards

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -12,6 +12,7 @@ checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
 name = "generativity"
 version = "1.2.0"
 dependencies = [
+ "never-say-never",
  "trybuild",
 ]
 
@@ -48,6 +49,12 @@ name = "memchr"
 version = "2.7.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32a282da65faaf38286cf3be983213fcf1d2e2a58700e808f83f4ea9a4804bc0"
+
+[[package]]
+name = "never-say-never"
+version = "6.6.666"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cf5a574dadd7941adeaa71823ecba5e28331b8313fb2e1c6a5c7e5981ea53ad6"
 
 [[package]]
 name = "proc-macro2"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,6 +11,7 @@ categories = ["no-std", "rust-patterns"]
 license = "MIT OR Apache-2.0"
 
 [dev-dependencies]
+never-say-never = "6.6.666"
 
 [dependencies]
 trybuild = "1.0.110"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,6 +12,4 @@ license = "MIT OR Apache-2.0"
 
 [dev-dependencies]
 never-say-never = "6.6.666"
-
-[dependencies]
 trybuild = "1.0.110"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -215,6 +215,11 @@ macro_rules! make_guard {
 
                 // Poorman's specialization; only shadowed in the
                 // `PhantomReturnType<!>` case.
+                //
+                // This is not strictly needed for soundness *per se*, since the above
+                // `forbid(unreachable_code)` takes care of that.
+                //
+                // But it greatly improves the diagnostics for the non-niche case.
                 #[allow(unused)]
                 use $crate::__private::DefaultReify as _;
                 return phantom_ret_ty.reify();

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -281,6 +281,8 @@ pub mod __private {
                 To this day, no workaround is known, so there is no other choice but to reject the \
                 `-> !`-returning function case: it is quite niche, and sacrificing it allows every \
                 other single instance of `make_guard!()` to remain sound.\
+                \n\
+                See https://github.com/CAD97/generativity/issues/15 for more info.
             ",
         )]
         pub trait SupportedReturnType {}

--- a/tests/ui/diverging_fn.rs
+++ b/tests/ui/diverging_fn.rs
@@ -1,0 +1,17 @@
+use generativity::{Id, make_guard};
+
+fn assert_eq_lt<'id>(_: Id<'id>, _: Id<'id>) {}
+
+fn diverging_fn() -> ! {
+    make_guard!(g_a);
+    make_guard!(g_b);
+
+    let a: Id = g_a.into();
+    let b: Id = g_b.into();
+
+    assert_eq_lt(a, b);
+
+    loop {}
+}
+
+fn main() {}

--- a/tests/ui/diverging_fn.stderr
+++ b/tests/ui/diverging_fn.stderr
@@ -4,18 +4,18 @@ error[E0277]: `make_guard!()` cannot be used in a diverging/`!`-returning functi
 6 |     make_guard!(g_a);
   |     ^^^^^^^^^^^^^^^^ encompassing functions "diverges", i.e., returns `-> !`
   |
-  = help: the trait `generativity::sealed::SupportedReturnType` is not implemented for `!`
+  = help: the trait `__private::sealed::SupportedReturnType` is not implemented for `!`
   = note: `make_guard!()` temporary and lifetime shenanigans, on which its soundness model hinges, are broken whenever both a diverging expression follows the `make_guard!()` statement(s), and also if the return type of the encompassing function is `!`, for technical reasons.
 
             To this day, no workaround is known, so there is no other choice but to reject the `-> !`-returning function case: it is quite niche, and sacrificing it allows every other single instance of `make_guard!()` to remain sound.
-note: required by a bound in `generativity::__private::Phony::<<fn() -> ! as __private::never_say_never::FnPtr>::Never>::get`
+note: required by a bound in `__private::<impl generativity::__private::Phony<<fn() -> ! as __private::never_say_never::FnPtr>::Never>>::get`
    --> src/lib.rs
     |
     |         pub fn get(&self) -> Never
     |                --- required by a bound in this associated function
-    |         where
-    |             for<'n> Never : sealed::SupportedReturnType,
-    |                             ^^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `Phony::<<fn() -> ! as FnPtr>::Never>::get`
+...
+    |             for<'trivial> Never : sealed::SupportedReturnType,
+    |                                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `__private::<impl Phony<<fn() -> ! as FnPtr>::Never>>::get`
     = note: this error originates in the macro `make_guard` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0277]: `make_guard!()` cannot be used in a diverging/`!`-returning function
@@ -24,16 +24,16 @@ error[E0277]: `make_guard!()` cannot be used in a diverging/`!`-returning functi
 7 |     make_guard!(g_b);
   |     ^^^^^^^^^^^^^^^^ encompassing functions "diverges", i.e., returns `-> !`
   |
-  = help: the trait `generativity::sealed::SupportedReturnType` is not implemented for `!`
+  = help: the trait `__private::sealed::SupportedReturnType` is not implemented for `!`
   = note: `make_guard!()` temporary and lifetime shenanigans, on which its soundness model hinges, are broken whenever both a diverging expression follows the `make_guard!()` statement(s), and also if the return type of the encompassing function is `!`, for technical reasons.
 
             To this day, no workaround is known, so there is no other choice but to reject the `-> !`-returning function case: it is quite niche, and sacrificing it allows every other single instance of `make_guard!()` to remain sound.
-note: required by a bound in `generativity::__private::Phony::<<fn() -> ! as __private::never_say_never::FnPtr>::Never>::get`
+note: required by a bound in `__private::<impl generativity::__private::Phony<<fn() -> ! as __private::never_say_never::FnPtr>::Never>>::get`
    --> src/lib.rs
     |
     |         pub fn get(&self) -> Never
     |                --- required by a bound in this associated function
-    |         where
-    |             for<'n> Never : sealed::SupportedReturnType,
-    |                             ^^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `Phony::<<fn() -> ! as FnPtr>::Never>::get`
+...
+    |             for<'trivial> Never : sealed::SupportedReturnType,
+    |                                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `__private::<impl Phony<<fn() -> ! as FnPtr>::Never>>::get`
     = note: this error originates in the macro `make_guard` (in Nightly builds, run with -Z macro-backtrace for more info)

--- a/tests/ui/diverging_fn.stderr
+++ b/tests/ui/diverging_fn.stderr
@@ -1,3 +1,19 @@
+error: unreachable expression
+ --> tests/ui/diverging_fn.rs:6:5
+  |
+6 |     make_guard!(g_a);
+  |     ^^^^^^^^^^^^^^^^
+  |     |
+  |     unreachable expression
+  |     any code following this expression is unreachable
+  |
+note: the lint level is defined here
+ --> tests/ui/diverging_fn.rs:6:5
+  |
+6 |     make_guard!(g_a);
+  |     ^^^^^^^^^^^^^^^^
+  = note: this error originates in the macro `make_guard` (in Nightly builds, run with -Z macro-backtrace for more info)
+
 error[E0277]: `make_guard!()` cannot be used in a diverging/`!`-returning function
  --> tests/ui/diverging_fn.rs:6:5
   |
@@ -8,6 +24,7 @@ error[E0277]: `make_guard!()` cannot be used in a diverging/`!`-returning functi
   = note: `make_guard!()` temporary and lifetime shenanigans, on which its soundness model hinges, are broken whenever both a diverging expression follows the `make_guard!()` statement(s), and also if the return type of the encompassing function is `!`, for technical reasons.
 
             To this day, no workaround is known, so there is no other choice but to reject the `-> !`-returning function case: it is quite niche, and sacrificing it allows every other single instance of `make_guard!()` to remain sound.
+    = help: the trait `__private::sealed::SupportedReturnType` is implemented for `()`
 note: required by a bound in `__private::<impl generativity::__private::Phony<<fn() -> ! as __private::never_say_never::FnPtr>::Never>>::get`
    --> src/lib.rs
     |
@@ -17,6 +34,22 @@ note: required by a bound in `__private::<impl generativity::__private::Phony<<f
     |             for<'trivial> Never : sealed::SupportedReturnType,
     |                                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `__private::<impl Phony<<fn() -> ! as FnPtr>::Never>>::get`
     = note: this error originates in the macro `make_guard` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error: unreachable expression
+ --> tests/ui/diverging_fn.rs:7:5
+  |
+7 |     make_guard!(g_b);
+  |     ^^^^^^^^^^^^^^^^
+  |     |
+  |     unreachable expression
+  |     any code following this expression is unreachable
+  |
+note: the lint level is defined here
+ --> tests/ui/diverging_fn.rs:7:5
+  |
+7 |     make_guard!(g_b);
+  |     ^^^^^^^^^^^^^^^^
+  = note: this error originates in the macro `make_guard` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0277]: `make_guard!()` cannot be used in a diverging/`!`-returning function
  --> tests/ui/diverging_fn.rs:7:5
@@ -28,6 +61,7 @@ error[E0277]: `make_guard!()` cannot be used in a diverging/`!`-returning functi
   = note: `make_guard!()` temporary and lifetime shenanigans, on which its soundness model hinges, are broken whenever both a diverging expression follows the `make_guard!()` statement(s), and also if the return type of the encompassing function is `!`, for technical reasons.
 
             To this day, no workaround is known, so there is no other choice but to reject the `-> !`-returning function case: it is quite niche, and sacrificing it allows every other single instance of `make_guard!()` to remain sound.
+    = help: the trait `__private::sealed::SupportedReturnType` is implemented for `()`
 note: required by a bound in `__private::<impl generativity::__private::Phony<<fn() -> ! as __private::never_say_never::FnPtr>::Never>>::get`
    --> src/lib.rs
     |

--- a/tests/ui/diverging_fn.stderr
+++ b/tests/ui/diverging_fn.stderr
@@ -1,0 +1,39 @@
+error[E0277]: `make_guard!()` cannot be used in a diverging/`!`-returning function
+ --> tests/ui/diverging_fn.rs:6:5
+  |
+6 |     make_guard!(g_a);
+  |     ^^^^^^^^^^^^^^^^ encompassing functions "diverges", i.e., returns `-> !`
+  |
+  = help: the trait `generativity::sealed::SupportedReturnType` is not implemented for `!`
+  = note: `make_guard!()` temporary and lifetime shenanigans, on which its soundness model hinges, are broken whenever both a diverging expression follows the `make_guard!()` statement(s), and also if the return type of the encompassing function is `!`, for technical reasons.
+
+            To this day, no workaround is known, so there is no other choice but to reject the `-> !`-returning function case: it is quite niche, and sacrificing it allows every other single instance of `make_guard!()` to remain sound.
+note: required by a bound in `generativity::__private::Phony::<<fn() -> ! as __private::never_say_never::FnPtr>::Never>::get`
+   --> src/lib.rs
+    |
+    |         pub fn get(&self) -> Never
+    |                --- required by a bound in this associated function
+    |         where
+    |             for<'n> Never : sealed::SupportedReturnType,
+    |                             ^^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `Phony::<<fn() -> ! as FnPtr>::Never>::get`
+    = note: this error originates in the macro `make_guard` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error[E0277]: `make_guard!()` cannot be used in a diverging/`!`-returning function
+ --> tests/ui/diverging_fn.rs:7:5
+  |
+7 |     make_guard!(g_b);
+  |     ^^^^^^^^^^^^^^^^ encompassing functions "diverges", i.e., returns `-> !`
+  |
+  = help: the trait `generativity::sealed::SupportedReturnType` is not implemented for `!`
+  = note: `make_guard!()` temporary and lifetime shenanigans, on which its soundness model hinges, are broken whenever both a diverging expression follows the `make_guard!()` statement(s), and also if the return type of the encompassing function is `!`, for technical reasons.
+
+            To this day, no workaround is known, so there is no other choice but to reject the `-> !`-returning function case: it is quite niche, and sacrificing it allows every other single instance of `make_guard!()` to remain sound.
+note: required by a bound in `generativity::__private::Phony::<<fn() -> ! as __private::never_say_never::FnPtr>::Never>::get`
+   --> src/lib.rs
+    |
+    |         pub fn get(&self) -> Never
+    |                --- required by a bound in this associated function
+    |         where
+    |             for<'n> Never : sealed::SupportedReturnType,
+    |                             ^^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `Phony::<<fn() -> ! as FnPtr>::Never>::get`
+    = note: this error originates in the macro `make_guard` (in Nightly builds, run with -Z macro-backtrace for more info)

--- a/tests/ui/diverging_fn.stderr
+++ b/tests/ui/diverging_fn.stderr
@@ -24,6 +24,8 @@ error[E0277]: `make_guard!()` cannot be used in a diverging/`!`-returning functi
   = note: `make_guard!()` temporary and lifetime shenanigans, on which its soundness model hinges, are broken whenever both a diverging expression follows the `make_guard!()` statement(s), and also if the return type of the encompassing function is `!`, for technical reasons.
 
             To this day, no workaround is known, so there is no other choice but to reject the `-> !`-returning function case: it is quite niche, and sacrificing it allows every other single instance of `make_guard!()` to remain sound.
+            See https://github.com/CAD97/generativity/issues/15 for more info.
+
 note: required by a bound in `PhantomReturnType::<<fn() -> ! as __private::never_say_never::FnPtr>::Never>::reify`
    --> src/lib.rs
     |
@@ -60,6 +62,8 @@ error[E0277]: `make_guard!()` cannot be used in a diverging/`!`-returning functi
   = note: `make_guard!()` temporary and lifetime shenanigans, on which its soundness model hinges, are broken whenever both a diverging expression follows the `make_guard!()` statement(s), and also if the return type of the encompassing function is `!`, for technical reasons.
 
             To this day, no workaround is known, so there is no other choice but to reject the `-> !`-returning function case: it is quite niche, and sacrificing it allows every other single instance of `make_guard!()` to remain sound.
+            See https://github.com/CAD97/generativity/issues/15 for more info.
+
 note: required by a bound in `PhantomReturnType::<<fn() -> ! as __private::never_say_never::FnPtr>::Never>::reify`
    --> src/lib.rs
     |

--- a/tests/ui/diverging_fn.stderr
+++ b/tests/ui/diverging_fn.stderr
@@ -18,21 +18,20 @@ error[E0277]: `make_guard!()` cannot be used in a diverging/`!`-returning functi
  --> tests/ui/diverging_fn.rs:6:5
   |
 6 |     make_guard!(g_a);
-  |     ^^^^^^^^^^^^^^^^ encompassing functions "diverges", i.e., returns `-> !`
+  |     ^^^^^^^^^^^^^^^^ encompassing functions "diverges", e.g., returns `-> !`
   |
   = help: the trait `__private::sealed::SupportedReturnType` is not implemented for `!`
   = note: `make_guard!()` temporary and lifetime shenanigans, on which its soundness model hinges, are broken whenever both a diverging expression follows the `make_guard!()` statement(s), and also if the return type of the encompassing function is `!`, for technical reasons.
 
             To this day, no workaround is known, so there is no other choice but to reject the `-> !`-returning function case: it is quite niche, and sacrificing it allows every other single instance of `make_guard!()` to remain sound.
-    = help: the trait `__private::sealed::SupportedReturnType` is implemented for `()`
-note: required by a bound in `__private::<impl generativity::__private::Phony<<fn() -> ! as __private::never_say_never::FnPtr>::Never>>::get`
+note: required by a bound in `PhantomReturnType::<<fn() -> ! as __private::never_say_never::FnPtr>::Never>::reify`
    --> src/lib.rs
     |
-    |         pub fn get(&self) -> Never
-    |                --- required by a bound in this associated function
+    |         pub fn reify(&self) -> Never
+    |                ----- required by a bound in this associated function
 ...
     |             for<'trivial> Never : sealed::SupportedReturnType,
-    |                                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `__private::<impl Phony<<fn() -> ! as FnPtr>::Never>>::get`
+    |                                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `PhantomReturnType::<<fn() -> ! as FnPtr>::Never>::reify`
     = note: this error originates in the macro `make_guard` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: unreachable expression
@@ -55,19 +54,18 @@ error[E0277]: `make_guard!()` cannot be used in a diverging/`!`-returning functi
  --> tests/ui/diverging_fn.rs:7:5
   |
 7 |     make_guard!(g_b);
-  |     ^^^^^^^^^^^^^^^^ encompassing functions "diverges", i.e., returns `-> !`
+  |     ^^^^^^^^^^^^^^^^ encompassing functions "diverges", e.g., returns `-> !`
   |
   = help: the trait `__private::sealed::SupportedReturnType` is not implemented for `!`
   = note: `make_guard!()` temporary and lifetime shenanigans, on which its soundness model hinges, are broken whenever both a diverging expression follows the `make_guard!()` statement(s), and also if the return type of the encompassing function is `!`, for technical reasons.
 
             To this day, no workaround is known, so there is no other choice but to reject the `-> !`-returning function case: it is quite niche, and sacrificing it allows every other single instance of `make_guard!()` to remain sound.
-    = help: the trait `__private::sealed::SupportedReturnType` is implemented for `()`
-note: required by a bound in `__private::<impl generativity::__private::Phony<<fn() -> ! as __private::never_say_never::FnPtr>::Never>>::get`
+note: required by a bound in `PhantomReturnType::<<fn() -> ! as __private::never_say_never::FnPtr>::Never>::reify`
    --> src/lib.rs
     |
-    |         pub fn get(&self) -> Never
-    |                --- required by a bound in this associated function
+    |         pub fn reify(&self) -> Never
+    |                ----- required by a bound in this associated function
 ...
     |             for<'trivial> Never : sealed::SupportedReturnType,
-    |                                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `__private::<impl Phony<<fn() -> ! as FnPtr>::Never>>::get`
+    |                                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `PhantomReturnType::<<fn() -> ! as FnPtr>::Never>::reify`
     = note: this error originates in the macro `make_guard` (in Nightly builds, run with -Z macro-backtrace for more info)

--- a/tests/ui/diverging_fn_cursed.rs
+++ b/tests/ui/diverging_fn_cursed.rs
@@ -1,0 +1,18 @@
+use generativity::{Id, make_guard};
+use never_say_never::Never;
+
+fn assert_eq_lt<'id>(_: Id<'id>, _: Id<'id>) {}
+
+fn diverging_fn_cursed() -> (Never, Never) {
+    make_guard!(g_a);
+    make_guard!(g_b);
+
+    let a: Id = g_a.into();
+    let b: Id = g_b.into();
+
+    assert_eq_lt(a, b);
+
+    loop {}
+}
+
+fn main() {}

--- a/tests/ui/diverging_fn_cursed.stderr
+++ b/tests/ui/diverging_fn_cursed.stderr
@@ -1,0 +1,41 @@
+error: unreachable expression
+ --> tests/ui/diverging_fn_cursed.rs:8:5
+  |
+8 |     make_guard!(g_b);
+  |     ^^^^^^^^^^^^^^^^
+  |     |
+  |     unreachable expression
+  |     any code following this expression is unreachable
+  |
+note: this expression has type `(!, !)`, which is uninhabited
+ --> tests/ui/diverging_fn_cursed.rs:8:5
+  |
+8 |     make_guard!(g_b);
+  |     ^^^^^^^^^^^^^^^^
+note: the lint level is defined here
+ --> tests/ui/diverging_fn_cursed.rs:8:5
+  |
+8 |     make_guard!(g_b);
+  |     ^^^^^^^^^^^^^^^^
+  = note: this error originates in the macro `make_guard` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error: unreachable expression
+ --> tests/ui/diverging_fn_cursed.rs:7:5
+  |
+7 |     make_guard!(g_a);
+  |     ^^^^^^^^^^^^^^^^
+  |     |
+  |     unreachable expression
+  |     any code following this expression is unreachable
+  |
+note: this expression has type `(!, !)`, which is uninhabited
+ --> tests/ui/diverging_fn_cursed.rs:7:5
+  |
+7 |     make_guard!(g_a);
+  |     ^^^^^^^^^^^^^^^^
+note: the lint level is defined here
+ --> tests/ui/diverging_fn_cursed.rs:7:5
+  |
+7 |     make_guard!(g_a);
+  |     ^^^^^^^^^^^^^^^^
+  = note: this error originates in the macro `make_guard` (in Nightly builds, run with -Z macro-backtrace for more info)

--- a/tests/ui/issue_15_panic_dropck.rs
+++ b/tests/ui/issue_15_panic_dropck.rs
@@ -1,0 +1,15 @@
+use generativity::{Id, make_guard};
+
+fn assert_eq_lt<'id>(_: Id<'id>, _: Id<'id>) {}
+
+fn main() {
+    make_guard!(g_a);
+    make_guard!(g_b);
+
+    let a: Id = g_a.into();
+    let b: Id = g_b.into();
+
+    assert_eq_lt(a, b);
+
+    loop {}
+}

--- a/tests/ui/issue_15_panic_dropck.stderr
+++ b/tests/ui/issue_15_panic_dropck.stderr
@@ -1,0 +1,14 @@
+error[E0716]: temporary value dropped while borrowed
+  --> tests/ui/issue_15_panic_dropck.rs:7:5
+   |
+7  |     make_guard!(g_b);
+   |     ^^^^^^^^^^^^^^^^ creates a temporary value which is freed while still in use
+...
+15 | }
+   | -
+   | |
+   | temporary value is freed at the end of this statement
+   | borrow might be used here, when `lifetime_brand` is dropped and runs the `Drop` code for type `LifetimeBrand`
+   |
+   = note: consider using a `let` binding to create a longer lived value
+   = note: this error originates in the macro `make_guard` (in Nightly builds, run with -Z macro-backtrace for more info)


### PR DESCRIPTION
  - Tentative fix for #15 

(Haven't had the time to properly clean up the implementation.)

This works off @CAD97's idea of the `if false { return None.unwrap(); }`.

As they pointed out, that technique will not work if the inferred type is itself `!`, since then our phony unreachable instance synthesizer (`phony()`) will just be perceived as a `!`-synthesizer function, _i.e._, yet another diverging function!

We work around that by using poorman's specialization to detect that case, _and straight up refusing to work_ then: (slightly) ⚠️ breaking change ⚠️. 